### PR TITLE
fix: field name not converted in @@index/@@id/@@unique with map option

### DIFF
--- a/src/__fixtures__/index-with-map.prisma
+++ b/src/__fixtures__/index-with-map.prisma
@@ -1,0 +1,15 @@
+model session_log {
+  id      Int       @id(map: "session_log_pk") @default(autoincrement())
+  user_id String    @db.Uuid
+  reg_at  DateTime? @default(now()) @db.Timestamp(6)
+
+  @@index([user_id], map: "user_id_idx")
+}
+
+model user {
+  id      Int       @id(map: "user_pk") @default(autoincrement())
+  user_id String    @db.Uuid
+  reg_at  DateTime? @default(now()) @db.Timestamp(6)
+
+  @@index([user_id])
+}

--- a/src/__snapshots__/fixer.test.ts.snap
+++ b/src/__snapshots__/fixer.test.ts.snap
@@ -274,6 +274,27 @@ enum Role {
 "
 `;
 
+exports[`fix > field-name with @@index map option (issue #13) 1`] = `
+"model SessionLog {
+  id     Int       @id(map: "session_log_pk") @default(autoincrement())
+  userId String    @map("user_id") @db.Uuid
+  regAt  DateTime? @default(now()) @map("reg_at") @db.Timestamp(6)
+
+  @@index([userId], map: "user_id_idx")
+  @@map("session_log")
+}
+
+model User {
+  id     Int       @id(map: "user_pk") @default(autoincrement())
+  userId String    @map("user_id") @db.Uuid
+  regAt  DateTime? @default(now()) @map("reg_at") @db.Timestamp(6)
+
+  @@index([userId])
+  @@map("user")
+}
+"
+`;
+
 exports[`fix > model-map 1`] = `
 "datasource db {
   provider = "postgresql"

--- a/src/blocks/model-block.test.ts
+++ b/src/blocks/model-block.test.ts
@@ -261,4 +261,31 @@ describe("ModelBlock", () => {
     expect(field3.getRelationFields()).toEqual(undefined);
     expect(field3.getRelationReferences()).toEqual(undefined);
   });
+
+  test("@@id, @@unique, @@index with map option", () => {
+    // Arrange
+    const lines = [
+      "model X {",
+      "  id1 Int",
+      "  id2 Int",
+      "  id3 Int",
+      "",
+      '  @@id([id1, id2], map: "x_pk")',
+      '  @@unique([id1], map: "x_unique")',
+      '  @@index([id2, id3], map: "x_idx")',
+      "}",
+    ];
+
+    // Act
+    const modelBlock = new ModelBlock();
+    lines.forEach((line) => modelBlock.appendLine(line));
+
+    // Assert
+    expect(modelBlock.getLines()).toEqual(lines);
+    expect(modelBlock.getIdLine()?.fields).toEqual(["id1", "id2"]);
+    expect(modelBlock.getUniqueLines().map((x) => x.fields)).toEqual([["id1"]]);
+    expect(modelBlock.getIndexLines().map((x) => x.fields)).toEqual([
+      ["id2", "id3"],
+    ]);
+  });
 });

--- a/src/blocks/model-block.ts
+++ b/src/blocks/model-block.ts
@@ -303,7 +303,7 @@ class MapLine implements Line {
 
 class IdLine implements Line {
   static readonly LINE_REGEX =
-    /^(?<before>\s+@@id\(\[)(?<fields>[^[]+)(?<after>\]\).*)$/;
+    /^(?<before>\s+@@id\(\[)(?<fields>[^[]+)(?<after>\].*)$/;
 
   private readonly before: string;
   fields: string[];
@@ -321,7 +321,7 @@ class IdLine implements Line {
 
 class UniqueLine implements Line {
   static readonly LINE_REGEX =
-    /^(?<before>\s+@@unique\(\[)(?<fields>[^[]+)(?<after>\]\).*)$/;
+    /^(?<before>\s+@@unique\(\[)(?<fields>[^[]+)(?<after>\].*)$/;
 
   private readonly before: string;
   fields: string[];
@@ -339,7 +339,7 @@ class UniqueLine implements Line {
 
 class IndexLine implements Line {
   static readonly LINE_REGEX =
-    /^(?<before>\s+@@index\(\[)(?<fields>[^[]+)(?<after>\]\).*)$/;
+    /^(?<before>\s+@@index\(\[)(?<fields>[^[]+)(?<after>\].*)$/;
 
   private readonly before: string;
   fields: string[];

--- a/src/fixer.test.ts
+++ b/src/fixer.test.ts
@@ -204,6 +204,25 @@ describe("fix", () => {
     // Assert
     expect(result).toMatchSnapshot();
   });
+
+  test("field-name with @@index map option (issue #13)", async () => {
+    // Arrange
+    const content = readFixture("index-with-map.prisma");
+    const config = defineConfig({
+      rules: {
+        "model-name": [{ case: "pascal" }],
+        "model-map": [{ case: "snake" }],
+        "field-name": [{ case: "camel" }],
+        "field-map": [{ case: "snake" }],
+      },
+    });
+
+    // Act
+    const result = await fix(content, config);
+
+    // Assert
+    expect(result).toMatchSnapshot();
+  });
 });
 
 const readFixture = (name: string): string => {

--- a/src/rules/field-name-rule.test.ts
+++ b/src/rules/field-name-rule.test.ts
@@ -308,4 +308,34 @@ describe("apply", () => {
       "}",
     ]);
   });
+
+  test("@@index with map option (issue #13)", () => {
+    // Arrange
+    const configs: FieldNameRule.Config[] = [{ case: "camel" }];
+    const blocks: Block[] = [
+      new ModelBlock([
+        "model SessionLog {",
+        '  id      Int       @id(map: "session_log_pk") @default(autoincrement())',
+        "  user_id String    @db.Uuid",
+        "  reg_at  DateTime? @default(now()) @db.Timestamp(6)",
+        "",
+        '  @@index([user_id], map: "user_id_idx")',
+        "}",
+      ]),
+    ];
+
+    // Act
+    FieldNameRule.apply(configs, blocks);
+
+    // Assert
+    expect(blocks[0].getLines()).toEqual([
+      "model SessionLog {",
+      '  id      Int       @id(map: "session_log_pk") @default(autoincrement())',
+      "  userId String    @db.Uuid",
+      "  regAt  DateTime? @default(now()) @db.Timestamp(6)",
+      "",
+      '  @@index([userId], map: "user_id_idx")',
+      "}",
+    ]);
+  });
 });

--- a/src/transform/block-transform.test.ts
+++ b/src/transform/block-transform.test.ts
@@ -370,6 +370,40 @@ describe("changeFieldName", () => {
       "}",
     ]);
   });
+
+  test("@@id @@unique @@index with map option", () => {
+    // Arrange
+    const blocks: Block[] = [
+      new ModelBlock([
+        "model X {",
+        "  id1 Int",
+        "  id2 Int",
+        "  id3 Int",
+        '  @@id([id1, id2], map: "x_pk")',
+        '  @@unique([id2], map: "x_unique")',
+        '  @@index([id1, id2], map: "x_idx")',
+        "}",
+      ]),
+    ];
+    const modelName = "X";
+    const from = "id2";
+    const to = "id2To";
+
+    // Act
+    changeFieldName(blocks, modelName, from, to);
+
+    // Assert
+    expect(blocks[0].getLines()).toEqual([
+      "model X {",
+      "  id1 Int",
+      "  id2To Int",
+      "  id3 Int",
+      '  @@id([id1, id2To], map: "x_pk")',
+      '  @@unique([id2To], map: "x_unique")',
+      '  @@index([id1, id2To], map: "x_idx")',
+      "}",
+    ]);
+  });
 });
 
 describe("changeEnumName", () => {


### PR DESCRIPTION
Fix #13

## Summary

Fixed a bug where field names were not converted inside `@@index`, `@@id`, and `@@unique` when those attributes had additional options such as `map`.

## Root Cause

`IdLine`, `UniqueLine`, and `IndexLine` had a `LINE_REGEX` that required `])` immediately after the field list. This caused lines like `@@index([field], map: "idx_name")` to be parsed as `OtherLine`, skipping the field name conversion in `changeFieldName`.

## Fix

Changed the `LINE_REGEX` of each class from `\])` to `\]`, so the `after` capture group picks up everything after the closing bracket (e.g. `, map: "idx_name")`).

## Tests

Added tests to cover the scenario:

- `src/blocks/model-block.test.ts`: parsing `@@id`/`@@unique`/`@@index` with `map` option
- `src/transform/block-transform.test.ts`: field name conversion with `map` option
- `src/rules/field-name-rule.test.ts`: `@@index([user_id], map: "user_id_idx")` → `@@index([userId], map: "user_id_idx")`
- `src/__fixtures__/index-with-map.prisma` + `src/fixer.test.ts`: end-to-end snapshot test